### PR TITLE
Adds configuration management for the docker plugin.

### DIFF
--- a/manifests/plugin/docker.pp
+++ b/manifests/plugin/docker.pp
@@ -1,0 +1,39 @@
+# == Class: serverdensity_agent::plugin::docker
+#
+# Defines Docker instances
+#
+# === Parameters
+#
+# [*docker_root*]
+#   Change the root directory to look at to get cgroup statistics. Useful when
+#   running inside a container with host directories mounted on a different
+#   folder.
+#   Default: /
+#
+# [*docker_socket_url*]
+#   String. Url to the docker daemon socket to reach the Docker API. HTTP also
+#   works.
+#   Default: unix://var/run/docker.sock
+#
+# [*docker_socket_timeout*]
+#   Timeout on Docker socket connection. You may have to increase it if you
+#   have many containers.
+#   Default: undef
+#
+# === Examples
+#
+# class { 'serverdensity_agent::plugin::docker':
+#   docker_socket_url     => 'unix://var/run/docker.sock',
+#   docker_socket_timeout => 5,
+# }
+#
+class serverdensity_agent::plugin::docker (
+  $docker_root = '/',
+  $docker_socket_url = 'unix://var/run/docker.sock',
+  $docker_socket_timeout = undef,
+  ) {
+  serverdensity_agent::plugin { 'docker':
+    config_content => template('serverdensity_agent/plugin/docker.yaml.erb'),
+  }
+}
+# vim: set ts=2 sw=2 tw=0 et:

--- a/templates/plugin/docker.yaml.erb
+++ b/templates/plugin/docker.yaml.erb
@@ -1,0 +1,10 @@
+init_config:
+  docker_root: <%= @docker_root %>
+
+<%- if @docker_socket_timeout -%>
+  socket_timeout: <%= @docker_socket_timeout %>
+<%- end -%>
+
+instances:
+  - url: <%= @docker_socket_url %>
+


### PR DESCRIPTION
The pattern I followed should match the plugins that already exist in SD.

FWIW, enabling this _should_ be as simple as adding:
```puppet
  user { 'sd-agent':
    groups =>["docker"]
  }

  include serverdensity_agent::plugin::docker
```